### PR TITLE
Fix: Improve inputs/path handling

### DIFF
--- a/.github/workflows/testing.yaml
+++ b/.github/workflows/testing.yaml
@@ -37,12 +37,31 @@ jobs:
       - name: "Run action: ${{ github.repository }} [Standard build]"
         uses: ./
         with:
-          path_prefix: "test-python-project/"
-          tox_build: false
+          path_prefix: "test-python-project"
 
       # Perform test build again with TOX
       - name: "Run action: ${{ github.repository }} [Build using TOX]"
         uses: ./
         with:
+          path_prefix: "test-python-project"
+          purge_artefact_path: true
+          tox_build: true
+
+      # Build with explicit versioning
+      - name: "Run action: ${{ github.repository }} [Explicit versioning]"
+        uses: ./
+        with:
           path_prefix: "test-python-project/"
           purge_artefact_path: true
+          tag: "v2.0.0"
+          artefact_path: "explicit_tag"
+
+      - name: "Validate artefacts from above build"
+        shell: bash
+        run: |
+          # Validate artefacts from above build
+          if (find 'test-python-project/explicit_tag' -name '*2.0.0*'); then
+            echo "Explicit tag/artefact path as expected ✅"
+          else
+            echo "Error: build artefact validation failed ❌"; exit 1
+          fi

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Supports these optional features:
 | ATTESTATIONS        | False    | False   | Attest build artefacts using GitHub Attestations           |
 | SIGSTORE_SIGN       | False    | False   | Uses SigStore to sign binary build artefacts               |
 | PATH_PREFIX         | False    |         | Path/directory to Python project code                      |
-| TOX_BUILD           | False    | True    | Builds using tox, if configuration file present            |
+| TOX_BUILD           | False    | False   | Builds using tox, if configuration file present            |
 
 Note: do not enable attestations for development/test builds
 

--- a/action.yaml
+++ b/action.yaml
@@ -24,7 +24,7 @@ inputs:
     type: boolean
     default: false
   TAG:
-    description: "Tag version/name for this specific build (semantic)"
+    description: "Explicit tag/version for this build (semantic)"
     required: false
     type: string
   ATTESTATIONS:
@@ -43,12 +43,11 @@ inputs:
     description: "Directory location containing project code"
     required: false
     type: string
-    default: ""
   TOX_BUILD:
     description: "Attempt to use TOX to perform build"
     required: false
     type: boolean
-    default: true
+    default: false
 
 outputs:
   BUILD_PYTHON_VERSION:
@@ -64,81 +63,34 @@ outputs:
     description: "Build artefacts will be output to this folder/directory"
     value: ${{ inputs.artefact_path }}
 
-
 runs:
   using: "composite"
   steps:
-    - name: "Pre-build steps"
+    - name: "Setup action/environment"
       shell: bash
       run: |
-        # Pre-build steps
-        echo "# 🐍 Python Build" >> "$GITHUB_STEP_SUMMARY"
+        # Setup action/environment
 
-        # Handle boolean inputs carefully, add to environment
-        ARTEFACT_UPLOAD=$(echo "${{ inputs.artefact_upload }}" |\
-        tr '[:upper:]' '[:lower:]')
-        ATTESTATIONS=$(echo "${{ inputs.attestations }}" |\
-        tr '[:upper:]' '[:lower:]')
-        SIGSTORE_SIGN=$(echo "${{ inputs.sigstore_sign }}" |\
-        tr '[:upper:]' '[:lower:]')
-        TOX_BUILD=$(echo "${{ inputs.tox_build }}" |\
-        tr '[:upper:]' '[:lower:]')
-        echo "artefact_upload=$ARTEFACT_UPLOAD" >> "$GITHUB_ENV"
-        echo "attestations=$ATTESTATIONS" >> "$GITHUB_ENV"
-        echo "sigstore_sign=$SIGSTORE_SIGN" >> "$GITHUB_ENV"
-        echo "tox_build=$TOX_BUILD" >> "$GITHUB_ENV"
-
-    - name: "Gather Python project metadata"
-      id: python-metadata
-      # yamllint disable-line rule:line-length
-      uses: lfreleng-actions/python-project-metadata-action@c3dcc3a603720f88d1cb6b855b95a4efad1db210 # v0.1.7
-      with:
-        path_prefix: "${{ inputs.path_prefix }}"
-
-    # Catch this condition early in build process
-    - name: "Check project version matches pushed tags"
-      if: startsWith(github.ref, 'refs/tags/')
-      # yamllint disable-line rule:line-length
-      uses: lfreleng-actions/python-project-tag-push-verify-action@27478ec0a2d9acc3a3dc80da4648f4d1eb9d429e # v0.1.0
-      with:
-        path_prefix: "${{ inputs.path_prefix }}"
-
-    - name: "Explicit build versioning step"
-      if: inputs.tag
-      shell: bash
-      run: |
-        # Explicit build versioning step
-        echo "Explicit build versioning: ${{ inputs.tag }} 💬"
-        echo "tag=${{ inputs.tag }}" >> "$GITHUB_ENV"
-
-    - name: "Patch project versioning metadata"
-      # Optionally patch Python project file to match requested build tag
-      if: env.python_project_version != inputs.tag
-      # yamllint disable-line rule:line-length
-      uses: lfreleng-actions/python-project-version-patch-action@ff8c1187171dbb476a5c42b044f9e48fb2331929 # v0.1.3
-      with:
-        replacement_version: ${{ env.tag }}
-        path_prefix: "${{ inputs.path_prefix }}"
-
-    - name: "Setup Python"
-      # yamllint disable-line rule:line-length
-      uses: actions/setup-python@8d9ed9ac5c53483de85588cdf95a591a75ab9f55 # v5.5.0
-      with:
-        # yamllint disable-line rule:line-length
-        python-version: "${{ steps.python-metadata.outputs.build_python_version }}"
-
-    - name: "Build Python project"
-      id: perform-build
-      shell: bash
-      run: |
-        # Build Python project
-
-        python -m pip install --disable-pip-version-check -q --upgrade pip
-
-        if [ ${{ inputs.path_prefix }} != '' ]; then
-          echo "Change to project directory: ${{ inputs.path_prefix }}"
-          cd ${{ inputs.path_prefix }}
+        # Handle path_prefix input consistently and when absent
+        path_prefix="${{ inputs.PATH_PREFIX }}"
+        if [ -z "$path_prefix" ]; then
+          # Set current directory as path prefix
+          path_prefix="."
+        else
+          # Strip any trailing slash in provided path
+          path_prefix="${path_prefix%/}"
         fi
+        # Verify is a valid directory path
+        if [ ! -d "$path_prefix" ]; then
+          echo "Error: invalid path/prefix to project directory ❌"; exit 1
+        fi
+        echo "path_prefix=$path_prefix" >> "$GITHUB_ENV"
+
+        # Output build heading
+        echo "# 🐍 Python Build" >> "$GITHUB_STEP_SUMMARY"
+        # Update PIP and build module
+        python -m pip install --disable-pip-version-check \
+          -q --upgrade pip build packaging
 
         # Set build parameters/variables
         echo "Action triggered by: ${GITHUB_TRIGGERING_ACTOR}"
@@ -148,61 +100,119 @@ runs:
         echo "datetime=${datetime}" >> "$GITHUB_OUTPUT"
 
         if [ ${{ inputs.PURGE_ARTEFACT_PATH }} ] && \
-           [ -d ${{ inputs.ARTEFACT_PATH }} ]; then
+           [ -d ${{ inputs.path_prefix }}/${{ inputs.ARTEFACT_PATH }} ]; then
           echo "Purging artefact output path prior to build ⚠️"
-          echo "Path: ${{ inputs.ARTEFACT_PATH }}"
-          rm -Rf ${{ inputs.ARTEFACT_PATH }}/*
+          echo "Path: ${{ inputs.path_prefix }}/${{ inputs.ARTEFACT_PATH }}"
+          rm -Rf ${{ inputs.path_prefix }}/${{ inputs.ARTEFACT_PATH }}/*
         fi
 
-        # TOX Build
-        if [ -f tox.ini ] && [ "f${{ env.tox_build }}" = "ftrue" ]; then
-          echo "TOX configuration file present: tox.ini"
+    - name: "Gather Python project metadata"
+      id: python-metadata
+      # yamllint disable-line rule:line-length
+      uses: lfreleng-actions/python-project-metadata-action@c3dcc3a603720f88d1cb6b855b95a4efad1db210 # v0.1.7
+      with:
+        path_prefix: "${{ env.path_prefix }}"
+
+    # Catch this condition early in build process
+    - name: "Check project version matches pushed tags"
+      if: startsWith(github.ref, 'refs/tags/')
+      # yamllint disable-line rule:line-length
+      uses: lfreleng-actions/python-project-tag-push-verify-action@27478ec0a2d9acc3a3dc80da4648f4d1eb9d429e # v0.1.0
+      with:
+        path_prefix: "${{ env.path_prefix }}"
+
+    - name: "Explicit build versioning"
+      if: inputs.tag != ''
+      shell: bash
+      run: |
+        # Explicit build versioning
+        echo "Explicit build versioning: ${{ inputs.tag }} 💬"
+
+    - name: "Patch project versioning metadata"
+      # Optionally patch Python project file to match requested build tag
+      if: env.python_project_version != inputs.tag
+      # yamllint disable-line rule:line-length
+      uses: lfreleng-actions/python-project-version-patch-action@ff8c1187171dbb476a5c42b044f9e48fb2331929 # v0.1.3
+      with:
+        replacement_version: ${{ inputs.tag }}
+        path_prefix: "${{ env.path_prefix }}"
+
+    - name: "Setup Python"
+      # yamllint disable-line rule:line-length
+      uses: actions/setup-python@8d9ed9ac5c53483de85588cdf95a591a75ab9f55 # v5.5.0
+      with:
+        # yamllint disable-line rule:line-length
+        python-version: "${{ steps.python-metadata.outputs.build_python_version }}"
+
+    - name: "Build with TOX"
+      # yamllint disable-line rule:line-length
+      if: ${{ env.tox_build == 'true' }}
+      shell: bash
+      run: |
+        # Perform build with TOX
+        if [ -f ${{ env.path_prefix }}/tox.ini ]; then
+          echo "TOX configuration file present: ${{ env.path_prefix }}/tox.ini"
           python -m pip install --disable-pip-version-check \
             -q --upgrade tox tox-gh-actions
-          echo "Attempting build with: tox -e build"
-          if (tox -e build); then
+          echo "Building with: tox --root ${{ env.path_prefix }} -e build"
+          if (tox --root ${{ env.path_prefix }} -e build); then
             echo "Build with TOX successful ✅"
           else
             echo "Build with TOX failed ❌"; exit 1
           fi
+        else
+          echo "Error: TOX configuration not found ❌"; exit 1
+        fi
 
-        # Python build module
-        elif [ -f pyproject.toml ] || [ -f setup.py ]; then
-          echo "Attempting build with: python -m build"
-          python -m pip install --disable-pip-version-check -q --upgrade build
-          if (python -m build --outdir ${{ inputs.ARTEFACT_PATH }}); then
+    - name: "Build Python project"
+      # yamllint disable-line rule:line-length
+      if: ${{ env.tox_build != 'true' }}
+      shell: bash
+      run: |
+        # Build Python project
+        if [ -f ${{ env.path_prefix }}/pyproject.toml ] || \
+        [ -f ${{ env.path_prefix }}/setup.py ]; then
+          if (python -m build --outdir \
+            ${{ env.path_prefix }}/${{ inputs.ARTEFACT_PATH }} \
+            ${{ env.path_prefix }}); then
             echo "Build with Python module successful ✅"
           else
             echo "Build with Python module failed ❌"; exit 1
           fi
+        else
+          echo "Error: project definition file not found ❌"; exit 1
         fi
 
-    - name: "Build summary"
+    - name: "Build outputs/summary"
       shell: bash
+      # yamllint disable rule:line-length
       run: |
-        # Build summary
+        # Build outputs/summary
         echo "artefact_name=${{ env.python_project_name }}" >> "$GITHUB_OUTPUT"
-        echo "artefact_path=${{ inputs.ARTEFACT_PATH }}" >> "$GITHUB_OUTPUT"
+        echo "artefact_path=${{ env.path_prefix }}/${{ inputs.ARTEFACT_PATH }}" \
+          >> "$GITHUB_OUTPUT"
         echo "Artefact name: ${{ env.python_project_name }}"
-        echo "Artefact path: ${{ inputs.ARTEFACT_PATH }}"
+        echo "Artefact path: ${{ env.path_prefix }}/${{ inputs.ARTEFACT_PATH }}"
         VERSION=$(python --version)
         echo "Build with $VERSION successful ✅"
         echo "Build with $VERSION successful ✅" >> "$GITHUB_STEP_SUMMARY"
 
     # Note: caution with sequencing of steps
     # Twine validation after attestations/signing causes failures
+    # yamllint enable rule:line-length
     - name: "Validate artefacts with Twine"
       # yamllint disable-line rule:line-length
       uses: lfreleng-actions/python-twine-check-action@514f458fad2cfe506da1e472d2a68c4297fcbf94 # v0.1.1
       with:
-        path: "${{ inputs.path_prefix }}${{ inputs.ARTEFACT_PATH }}"
+        path_prefix: ${{ env.path_prefix }}
+        path: "${{ inputs.ARTEFACT_PATH }}"
 
-    - name: "Artefact attestation for: ${{ inputs.ARTEFACT_PATH }}"
+    - name: "Perform artefact attestations"
       # yamllint disable-line rule:line-length
       uses: actions/attest-build-provenance@c074443f1aee8d4aeeae555aebba3282517141b2 # v2.2.3
       if: ${{ env.attestations == 'true' }}
       with:
-        subject-path: "${{ inputs.path_prefix }}${{ inputs.ARTEFACT_PATH }}/*"
+        subject-path: "${{ env.path_prefix }}/${{ inputs.ARTEFACT_PATH }}/*"
 
     - name: "Add heading to separate signing from attestations"
       if: ${{ env.sigstore_sign == 'true' }}
@@ -217,11 +227,11 @@ runs:
       # yamllint disable-line rule:line-length
       uses: sigstore/gh-action-sigstore-python@f514d46b907ebcd5bedc05145c03b69c1edd8b46 # v3.0.0
       env:
-        package-path: "${{ inputs.path_prefix }}${{ inputs.ARTEFACT_PATH }}"
+        package-path: "${{ inputs.path_prefix }}/${{ inputs.ARTEFACT_PATH }}"
       with:
         inputs: >-
-          ./${{ inputs.path_prefix }}${{ inputs.ARTEFACT_PATH }}/*.tar.gz
-          ./${{ inputs.path_prefix }}${{ inputs.ARTEFACT_PATH }}/*.whl
+          ./${{ env.path_prefix }}${{ inputs.ARTEFACT_PATH }}/*.tar.gz
+          ./${{ env.path_prefix }}${{ inputs.ARTEFACT_PATH }}/*.whl
 
     - name: "Upload build artefacts"
       if: ${{ env.artefact_upload == 'true' }}
@@ -229,6 +239,6 @@ runs:
       uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
       with:
         name: "${{ env.python_project_name }}"
-        path: "${{ inputs.path_prefix }}${{ inputs.ARTEFACT_PATH }}"
+        path: "${{ env.path_prefix }}/${{ inputs.ARTEFACT_PATH }}"
         if-no-files-found: error
         overwrite: ${{ inputs.PURGE_ARTEFACT_PATH }}


### PR DESCRIPTION
Rather than change path during build, setup relative paths. This brings this action into alignment with changes made to the python-test-action (and others). The default build mechanism has also been toggled to the Python build module rather than TOX, since TOX builds cannot accept some of the configuration/inputs. I will raise a separate pull request so that TOX builds provide a warning when options are provided that cannot be actioned.