### PR TITLE
Fix: Expand build backend and dependency manager support

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,16 @@ The action performs the following steps to perform the build:
 
 Note: this build action is primarily designed around modern PEP standards.
 
+## Caching
+
+This action automatically caches Python dependencies for all major dependency
+managers (pip, poetry, pipenv) and build backends. The cache key includes the
+OS, Python version, and a hash of all relevant dependency files
+(`requirements.txt`, `pyproject.toml`, `poetry.lock`, `Pipfile*`, `setup.py`,
+`setup.cfg`).
+
+This ensures reliable, up-to-date builds for all supported Python project types.
+
 ## Notes
 
 When PURGE_ARTEFACT_PATH requested, actions/upload-artefacts will permit

--- a/action.yaml
+++ b/action.yaml
@@ -11,49 +11,49 @@ inputs:
   artefact_path:
     description: 'Build artefacts will be output to this folder/directory'
     required: false
-    type: string
+    # type: string
     default: 'dist'
   artefact_upload:
     description: 'Upload artefacts to GitHub once build completed'
     required: false
-    type: boolean
-    default: true
+    # type: boolean
+    default: 'true'
   purge_artefact_path:
     description: 'Purge artefact path prior to performing build'
     required: false
-    type: boolean
-    default: false
+    # type: boolean
+    default: 'false'
   tag:
     description: 'Explicit tag/version for this build (semantic)'
     required: false
-    type: string
+    # type: string
   skip_version_patch:
     description: 'Skip version patching (support dynamic versioning)'
     required: false
-    type: boolean
-    default: false
+    # type: boolean
+    default: 'false'
   attestations:
     # Attestations should NOT be enabled for development builds
     description: 'Apply GitHub attestations to artefacts'
     required: false
-    type: boolean
-    default: false
+    # type: boolean
+    default: 'false'
   sigstore_sign:
     # Signing should NOT be enabled for development builds
     description: 'Sign build artefacts with Sigstore'
     required: false
-    type: boolean
-    default: false
+    # type: boolean
+    default: 'false'
   path_prefix:
     description: 'Directory location containing project code'
     required: false
-    type: string
+    # type: string
     default: '.'
   tox_build:
     description: 'Attempt to use TOX to perform build'
     required: false
-    type: boolean
-    default: false
+    # type: boolean
+    default: 'false'
 
 outputs:
   build_python_version:
@@ -140,13 +140,23 @@ runs:
         # yamllint disable-line rule:line-length
         python-version: "${{ steps.python-metadata.outputs.build_python_version }}"
 
-    - name: 'Cache pip packages'
+    - name: 'Cache Python dependencies'
       uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
       with:
-        path: ~/.cache/pip
-        key: ${{ runner.os }}-pip-${{ hashFiles('**/pyproject.toml') }}
+        path: |
+          ~/.cache/pip
+          ~/.cache/pypoetry
+          ~/.cache/pipenv
+          .venv
+          .tox
+        # yamllint disable rule:line-length
+        key: >-
+          python-${{ runner.os }}-${{ steps.python-metadata.outputs.build_python_version }}-
+          ${{ hashFiles('**/requirements*.txt', '**/pyproject.toml', '**/poetry.lock', '**/Pipfile*', '**/setup.py', '**/setup.cfg') }}
         restore-keys: |
-          ${{ runner.os }}-pip-
+          python-${{ runner.os }}-${{ steps.python-metadata.outputs.build_python_version }}-
+          python-${{ runner.os }}-
+        # yamllint enable rule:line-length
 
     - name: 'Install build dependencies'
       shell: bash


### PR DESCRIPTION
Improve caching and cache keys for wider support and smarter behaviour. Include the Python version in the cache keys to prevent cross-contamination of caches.

Also, comment out invalid action input/type declarations to prevent JSON schema errors. Single quote default string/input values. This addresses two separate potential linting/formatting problems.