### PR TITLE
Feat: Add builds of test project with dynamic versioning

### DIFF
--- a/.github/workflows/testing.yaml
+++ b/.github/workflows/testing.yaml
@@ -39,11 +39,10 @@ jobs:
           path: "test-python-project"
 
       # Perform test build
-      - name: "Run action: ${{ github.repository }} [Standard build]"
+      - name: "Run action: ${{ github.repository }} [Static versioning]"
         uses: ./
         with:
           path_prefix: "test-python-project"
-
       # Perform test build again with TOX
       - name: "Run action: ${{ github.repository }} [Build using TOX]"
         uses: ./
@@ -70,3 +69,19 @@ jobs:
           else
             echo "Error: build artefact validation failed ❌"; exit 1
           fi
+
+      - name: "Swap test project to dynamic versioning"
+        shell: bash
+        run: |
+          # Swap test project to dynamic versioning
+          cp test-python-project/variations/dynamic.toml \
+            test-python-project/pyproject.toml
+
+      # Perform test build for dynamically versioned project
+      - name: "Run action: ${{ github.repository }} [Dynamic versioning]"
+        # Expect to fail until support is fully implemented
+        continue-on-error: true
+        uses: ./
+        with:
+          path_prefix: "test-python-project"
+          purge_artefact_path: true


### PR DESCRIPTION
Update action test regime to initiate builds of a project where pyproject.toml contains the following stanza:

  dynamic = ["version"]

Subsequent pull requests will be required to build succesfully. Because these test builds are expected to fail, we have set:

  continue-on-error: true