### PR TITLE
Fix: isolate Sigstore from project UV config

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -543,6 +543,13 @@ runs:
       if: inputs.sigstore_sign == 'true'
       # yamllint disable-line rule:line-length
       uses: sigstore/gh-action-sigstore-python@04cffa1d795717b140764e8b640de88853c92acc # v3.3.0
+      env:
+        # Prevent uv inside the sigstore action from discovering the
+        # calling project's pyproject.toml [tool.uv] configuration.
+        # Without this, constraint-dependencies (e.g. pygments>=2.20.0)
+        # leak into the action's isolated venv and conflict with its
+        # own pinned dependencies (e.g. pygments==2.19.2 via rich).
+        UV_NO_CONFIG: '1'
       with:
         inputs: ${{ env.SIGSTORE_FILES }}
 


### PR DESCRIPTION
## Problem

The `sigstore/gh-action-sigstore-python` action uses `uv` to install its
dependencies into an isolated venv. However, `uv` discovers and applies
`[tool.uv]` configuration from any `pyproject.toml` found in the current
working directory (and parent directories).

Since the CWD defaults to `$GITHUB_WORKSPACE` (the checked-out repository
root), any `constraint-dependencies` in the project's `pyproject.toml`
**leak into the sigstore action's dependency resolver**. This causes
unsatisfiable dependency conflicts when the project's constraints are
incompatible with the action's own pinned dependencies.

### Concrete example

In `lftools-uv`, the project has:

```toml
[tool.uv]
constraint-dependencies = [
    "pygments>=2.20.0",  # Security: ReDoS fixes
]
```

The sigstore action pins `pygments==2.19.2` (via `rich` to `sigstore`).
When `uv pip install` runs from the repo root, it sees both requirements
and fails:

> Because you require `pygments==2.19.2` and `pygments>=2.20.0`, we can
> conclude that your requirements are unsatisfiable.

### Root cause chain

1. `python-build-action` calls `sigstore/gh-action-sigstore-python`
   without setting `working-directory`
2. The sigstore action's `setup/setup.bash` runs
   `uv pip install --requirement .../main.txt`
3. `uv` discovers the project's `pyproject.toml` in CWD
4. `[tool.uv] constraint-dependencies` are applied to the resolver
5. **Conflict** between the project's floor pin and sigstore's exact pin

## Fix

Set `UV_NO_CONFIG=1` as an environment variable on the sigstore signing
step. This tells `uv` to ignore all configuration files, making the
action's dependency installation fully hermetic regardless of what the
calling project has in its `pyproject.toml`.

This is scoped to only the sigstore step -- it does not affect any other
steps in the action.

## Related

- Ideally `sigstore/gh-action-sigstore-python` would also fix this
  upstream (by passing `--no-config` or setting `UV_NO_CONFIG=1` in
  their `setup.bash`), but this defensive fix insulates us regardless.