### PR TITLE
Fix: remove pip self-upgrade after ensurepip

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -283,17 +283,16 @@ runs:
         # On some runners (e.g. ubuntu-24.04-arm), actions/setup-python
         # may not bootstrap pip correctly, resulting in:
         #   ModuleNotFoundError: No module named 'pip'
-        ensurepip_ran=false
+        # Note: do NOT run 'pip install --upgrade pip' after ensurepip;
+        # pip's self-upgrade can destroy its own installation, leaving
+        # the module unimportable (observed with pip 26.x on Py 3.12).
         if ! python -m pip --version > /dev/null 2>&1; then
           echo "pip not found; running ensurepip 🔧"
           python -m ensurepip --upgrade
-          ensurepip_ran=true
         fi
-        if [ "$ensurepip_ran" = true ]; then
-          python -m pip install --disable-pip-version-check \
-            -q --upgrade pip
-        fi
-        echo "$(python -m pip --version) ✅"
+        # Final verification; fail fast if pip is still broken
+        python -m pip --version
+        echo "pip module check passed ✅"
 
     - name: 'Install build dependencies'
       shell: bash


### PR DESCRIPTION
## Problem

The "Ensure pip is available" step (added in #160) correctly detects
missing pip and runs `ensurepip`, but then immediately runs
`pip install --upgrade pip`. On pip 26.x with Python 3.12.13, this
self-upgrade **destroys** the pip installation:

```
python -m pip not found; running ensurepip ⚠️
Looking in links: /tmp/tmpx7tm46ez
Processing /tmp/tmpx7tm46ez/pip-25.0.1-py3-none-any.whl
Installing collected packages: pip
Successfully installed pip-26.0.1
/opt/hostedtoolcache/Python/3.12.13/x64/bin/python: No module named pip
```

`ensurepip` bootstraps pip 25.0.1 successfully, but the subsequent
`pip install --upgrade pip` to 26.0.1 corrupts the installation,
leaving the module unimportable.

## Fix

Remove the `pip install --upgrade pip` call after `ensurepip`. The
ensurepip-bundled version is fully sufficient for installing and
building packages. The self-upgrade adds unnecessary risk with no
practical benefit.

A comment is added explaining why the upgrade is intentionally omitted,
to prevent future contributors from re-adding it.

## Related

A corresponding fix has been submitted to
`lfreleng-actions/python-test-action` as well (lfreleng-actions/python-test-action#131).