### PR TITLE
Docs: Refresh manylinux example to current Python set

### DIFF
--- a/docs/MANYLINUX_CONFIG.md
+++ b/docs/MANYLINUX_CONFIG.md
@@ -345,7 +345,7 @@ jobs:
             platform: x86_64
           - runner: ubuntu-24.04-arm
             platform: aarch64
-        python-version: ['3.9', '3.10', '3.11', '3.12']
+        python-version: ['3.10', '3.11', '3.12', '3.13', '3.14']
 
     runs-on: ${{ matrix.arch.runner }}
 


### PR DESCRIPTION
## Summary

Refresh the example `python-version` matrix in `docs/MANYLINUX_CONFIG.md` so it reflects the currently supported CPython minor releases:

- **Drop** Python 3.9 (reached end-of-life 2025-10-31).
- **Add** Python 3.14 (released 2025-10-07; bugfix support through 2030-10 per [PEP 745](https://peps.python.org/pep-0745/) and the [python.org dev guide](https://devguide.python.org/versions/)).

```diff
- python-version: ['3.9', '3.10', '3.11', '3.12']
+ python-version: ['3.10', '3.11', '3.12', '3.13', '3.14']
```

## Why

The example was four versions behind the upstream release cadence. Anyone copy-pasting it would have inherited an EOL minor (3.9) and missed the current stable release (3.14).

## Scope note

The runtime fallback Python matrix used by this action at execution time is sourced from [`lfreleng-actions/build-metadata-action`](https://github.com/lfreleng-actions/build-metadata-action) and is out of scope for this PR. A separate change against that repository would be needed to update defaults consumers see when project metadata is silent.

## Audit

`git --no-pager grep -nE '3\.(7|8|9)' -- '*.md' '*.yaml' '*.yml'` confirms `docs/MANYLINUX_CONFIG.md` was the only file in this repo carrying an EOL Python reference. No other examples or workflow files needed touching.