### PR TITLE
Feat(action)!: Remove clear_cache input

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,7 +141,6 @@ jobs:
 | tox_build           | False    | false          | Builds using tox, if configuration file exists              |
 | skip_version_patch  | False    | false          | Skip version patching (support dynamic versioning)          |
 | python_version      | False    |                | Override Python version for build (uses metadata if unset)  |
-| clear_cache         | False    | false          | Clears Python dependency caches                             |
 | build_formats       | False    | both           | Build formats: wheel, sdist, or both                        |
 | auditwheel          | False    | false          | Run auditwheel to repair wheels for manylinux compatibility |
 | manylinux_version   | False    | manylinux_2_34 | Target manylinux version for auditwheel                     |
@@ -175,14 +174,6 @@ Different features require different permission levels:
 ```yaml
 permissions:
   contents: read
-```
-
-### With Cache Clearing
-
-```yaml
-permissions:
-  contents: read
-  actions: write  # Required for cache deletion
 ```
 
 ### With Attestations and/or Signing
@@ -308,50 +299,11 @@ types.
 
 ### Cache Clearing
 
-To clear all Python dependency caches for the repository, set the
-`clear_cache` input to `true`. This performs the following:
-
-1. Delete all existing Python dependency caches, unconditionally
-2. Force fresh installation of all dependencies
-3. Create a new cache for future workflow runs
-
-Use this when:
-
-- Troubleshooting dependency resolution issues
-- Testing with new Python versions where cached dependencies are problematic
-- Ensuring a clean build environment
-
-**Note:** Requires `actions: write` permission in the workflow (see
-[Required Permissions](#required-permissions) section).
-
-Example with `workflow_dispatch`:
-
-<!-- markdownlint-disable MD013 -->
-
-```yaml
-on:
-  workflow_dispatch:
-    inputs:
-      clear_cache:
-        description: 'Clear all Python dependency caches'
-        type: boolean
-        default: false
-
-jobs:
-  build:
-    permissions:
-      contents: read
-      actions: write  # Required for cache deletion
-    steps:
-      - name: 'Checkout repository'
-        uses: actions/checkout@v4
-      - name: 'Build Python project'
-        uses: lfreleng-actions/python-build-action@3552106f5c8bfedebe4c38116abf3b9c289359ea  # v0.1.22
-        with:
-          clear_cache: ${{ github.event.inputs.clear_cache }}
-```
-
-<!-- markdownlint-enable MD013 -->
+This action does not clear Python dependency caches. Cache clearing now
+lives in a dedicated workflow that can target specific cache/project types
+(for example Python, Docker, or Go) via filters. Separating cache clearing
+from the build keeps the `actions: write` permission out of the build job,
+following the principle of least privilege and separation of concerns.
 
 ## Notes
 

--- a/action.yaml
+++ b/action.yaml
@@ -60,11 +60,6 @@ inputs:
     required: false
     # type: boolean
     default: 'false'
-  clear_cache:
-    description: 'Clear all Python dependency caches for this repository'
-    required: false
-    # type: boolean
-    default: 'false'
   python_version:
     description: >-
       Override Python version for build (uses metadata detection if not set)
@@ -302,25 +297,6 @@ runs:
       with:
         # yamllint disable-line rule:line-length
         python-version: "${{ steps.python_version.outputs.python_version }}"
-
-    - name: 'Clear Python dependency caches'
-      if: inputs.clear_cache == 'true'
-      shell: bash
-      env:
-        GH_TOKEN: ${{ github.token }}
-      run: |
-        # Clear Python dependency caches
-        echo "Clearing Python dependency caches 🗑️"
-        output="$(gh cache delete --all 2>&1)" || exit_code=$?
-        if [ -z "${exit_code:-}" ]; then
-          echo "Cache clearing completed ✅" >> "$GITHUB_STEP_SUMMARY"
-        else
-          # Cache clearing should not be fatal; minimal output to summary
-          echo "Cache clearing was not successful 💬" >> "$GITHUB_STEP_SUMMARY"
-          # More detailed information goes to the console/log output
-          echo "gh cache exit code: ${exit_code} 💬"
-          echo "$output"
-        fi
 
     - name: 'Cache Python dependencies'
       uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5


### PR DESCRIPTION
## Summary

Removes the `clear_cache` input from the action, along with all related
functionality, conditional logic, documentation, and permission guidance.

This is a **breaking change** (`!`).

## Why

Cache clearing now lives in a dedicated workflow that can clear caches based
on filters for specific cache/project types (Python, Docker, Go, etc.).

The permissions required to clear caches need to be separated from the build
functions. Keeping `clear_cache` in this action forced build jobs to be
granted the broader `actions: write` permission. For security reasons, we
remove this feature here to separate concerns and honour the principle of
least privilege.

## Changes

- **`action.yaml`**
  - Removed the `clear_cache` input definition.
  - Removed the `Clear Python dependency caches` step (including its
    `if: inputs.clear_cache == 'true'` conditional and the
    `gh cache delete --all` logic).
- **`README.md`**
  - Removed the `clear_cache` row from the inputs table.
  - Removed the "With Cache Clearing" permissions block (`actions: write`).
  - Replaced the "Cache Clearing" section with a note directing users to the
    dedicated cache-clearing workflow.

Net: 5 insertions, 77 deletions. No `clear_cache` references remain and
`action.yaml` validates as YAML.

## Breaking change / migration

The `clear_cache` input has been removed. Callers that set `clear_cache`
must migrate to the dedicated cache-clearing workflow. Build jobs no longer
need `actions: write` for cache clearing.

## Validation

All pre-commit hooks pass (yamllint, write-good, markdownlint, actionlint
validation, reuse, codespell, etc.).